### PR TITLE
fix(e2e): isolate suite promotion failures

### DIFF
--- a/src/main/java/org/remus/giteabot/prworkflow/e2e/promotion/SuitePromotionService.java
+++ b/src/main/java/org/remus/giteabot/prworkflow/e2e/promotion/SuitePromotionService.java
@@ -77,6 +77,16 @@ public class SuitePromotionService {
 
     public Outcome promote(Bot bot, PrWorkflowRun run, PrTestSuite suite,
                            String repoOwner, String repoName, String featureBranch) {
+        try {
+            return promoteInternal(bot, run, suite, repoOwner, repoName, featureBranch);
+        } catch (RuntimeException e) {
+            log.error("M7 promotion failed unexpectedly for {}/{}", repoOwner, repoName, e);
+            return Outcome.failure("Unexpected promotion failure: " + e.getMessage());
+        }
+    }
+
+    private Outcome promoteInternal(Bot bot, PrWorkflowRun run, PrTestSuite suite,
+                                    String repoOwner, String repoName, String featureBranch) {
         if (suite == null || suite.getCases() == null || suite.getCases().isEmpty()) {
             return Outcome.skipped("No generated test cases to promote.");
         }
@@ -323,4 +333,3 @@ public class SuitePromotionService {
 
     }
 }
-

--- a/src/test/java/org/remus/giteabot/prworkflow/e2e/E2ETestWorkflowTest.java
+++ b/src/test/java/org/remus/giteabot/prworkflow/e2e/E2ETestWorkflowTest.java
@@ -273,6 +273,40 @@ class E2ETestWorkflowTest {
     }
 
     @Test
+    void promotionFailure_doesNotChangeSuccessfulWorkflowStatus() {
+        TestSuiteRunner passing = new TestSuiteRunner() {
+            @Override public E2eTestFramework framework() { return E2eTestFramework.PLAYWRIGHT; }
+            @Override public TestSuiteOutcome run(TestSuiteRequest request) {
+                return TestSuiteOutcome.passed("all green", 1);
+            }
+        };
+        E2ETestWorkflow w = new E2ETestWorkflow(deploymentOrchestrator, suiteRepository,
+                workspaceManager, new TestSuiteRunnerRegistry(List.of(passing)),
+                selectionService, giteaClientFactory,
+                suitePromotionService, runRepository);
+
+        Bot bot = bot(new DeploymentTarget());
+        WebhookPayload payload = payload("acme", "web", 24L, "headAA");
+        payload.getPullRequest().getHead().setRef("feature/x");
+        when(deploymentOrchestrator.requestDeployment(any()))
+                .thenReturn(DeploymentResult.ready("https://x", "{}"));
+        when(selectionService.resolveParams(anyLong(), eq(E2ETestWorkflow.KEY)))
+                .thenReturn(Map.of("suiteLifecycle", "offer-as-pr"));
+        org.remus.giteabot.prworkflow.PrWorkflowRun runEntity =
+                new org.remus.giteabot.prworkflow.PrWorkflowRun();
+        runEntity.setId(42L);
+        when(runRepository.findById(42L)).thenReturn(java.util.Optional.of(runEntity));
+        when(suitePromotionService.promote(any(), any(), any(), eq("acme"), eq("web"), eq("feature/x")))
+                .thenReturn(org.remus.giteabot.prworkflow.e2e.promotion.SuitePromotionService.Outcome
+                        .failure("push failed"));
+
+        WorkflowResult result = w.run(ctx(bot, payload));
+
+        assertThat(result.status()).isEqualTo(WorkflowResultStatus.SUCCESS);
+        assertThat(result.summary()).isEqualTo("all green");
+    }
+
+    @Test
     void ephemeralLifecycle_skipsPromotionService() {
         Bot bot = bot(new DeploymentTarget());
         WebhookPayload payload = payload("acme", "web", 23L, "headZZ");

--- a/src/test/java/org/remus/giteabot/prworkflow/e2e/promotion/SuitePromotionServiceTest.java
+++ b/src/test/java/org/remus/giteabot/prworkflow/e2e/promotion/SuitePromotionServiceTest.java
@@ -251,6 +251,20 @@ class SuitePromotionServiceTest {
     }
 
     @Test
+    void unexpectedRuntimeException_surfacesAsOutcomeFailure() {
+        when(repoClient.getDefaultBranch("acme", "web"))
+                .thenThrow(new IllegalStateException("provider unavailable"));
+
+        SuitePromotionService.Outcome out = service.promote(bot(), run(1L),
+                suite(SuiteLifecycleMode.PROMOTE_ON_MERGE, 7L,
+                        caseAt("login.spec.ts", "// hi")),
+                "acme", "web", "feature/x");
+
+        assertThat(out.kind()).isEqualTo(SuitePromotionService.Outcome.Kind.FAILED);
+        assertThat(out.message()).contains("provider unavailable");
+    }
+
+    @Test
     void resolveConflict_suffixesBeforeFirstDot() throws IOException {
         Path base = Files.createDirectories(workspace.resolve("d"));
         Files.writeString(base.resolve("a.spec.ts"), "x");


### PR DESCRIPTION
## What has been done?

- Converted unexpected runtime failures across suite promotion into a failed promotion outcome.
- Added a service regression test for provider failures.
- Added a workflow regression test proving that failed promotion does not replace an already successful E2E result.

## Why?

Suite promotion is a follow-up action and promises to report failures without rolling back the original workflow. An escaped runtime exception could instead make an otherwise successful E2E run fail.

## What has been tested?

- SuitePromotionServiceTest and E2ETestWorkflowTest in the Maven Java 21 container.
- Full mvn -q clean verify in the Maven Java 21 container.
- git diff --check origin/develop...HEAD.

## How AI was used?

AI helped isolate this fix from superseded #368, trace the workflow status path, add focused regression tests, and review the final three-file diff.