### PR TITLE
fix: retry transient AI network write failures

### DIFF
--- a/src/main/java/org/remus/giteabot/agent/loop/AgentLoop.java
+++ b/src/main/java/org/remus/giteabot/agent/loop/AgentLoop.java
@@ -10,6 +10,7 @@ import org.remus.giteabot.ai.ChatTurn;
 import org.remus.giteabot.ai.ToolDescriptor;
 import org.springframework.web.client.HttpClientErrorException;
 
+import java.net.SocketException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -327,22 +328,24 @@ public final class AgentLoop {
     }
 
     /**
-     * Calls the AI with retry-and-compact logic for "prompt too long" errors.
+     * Calls the AI with a bounded retry for recoverable provider failures.
      * When the provider rejects the request because the prompt exceeds its
      * context window, this method aggressively compacts the in-memory history
      * (keeping only the last 2 compaction units) and retries once.
+     * Transient socket write failures, such as a broken pipe or connection
+     * reset, are also retried once without modifying the conversation.
      *
-     * <p>If the second attempt also fails with a prompt-too-long error, the
-     * exception is re-thrown to the caller.</p>
+     * <p>All other failures, and any failure on the second attempt, are
+     * re-thrown to the caller.</p>
      *
      * @return the {@link ChatTurn} from the successful AI call
-     * @throws HttpClientErrorException if the retry also fails
+     * @throws RuntimeException if the failure is not retryable or the retry fails
      */
     private ChatTurn callAiWithRetry(List<AiMessage> history, String currentMessage,
                                      List<ToolDescriptor> tools, String systemPrompt,
                                      ToolingMode resolvedMode) {
-        int maxRetries = 2;
-        for (int attempt = 1; attempt <= maxRetries; attempt++) {
+        int maxAttempts = 2;
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
             try {
                 if (resolvedMode == ToolingMode.NATIVE) {
                     return aiClient.chatWithTools(history, currentMessage, tools, systemPrompt,
@@ -352,19 +355,53 @@ public final class AgentLoop {
                             null, budget.maxTokensPerCall());
                     return ChatTurn.text(text);
                 }
-            } catch (HttpClientErrorException e) {
-                if (!aiClient.isPromptTooLongError(e) || attempt == maxRetries) {
+            } catch (RuntimeException e) {
+                boolean promptTooLong = e instanceof HttpClientErrorException clientError
+                        && aiClient.isPromptTooLongError(clientError);
+                boolean transientNetworkWriteFailure = isTransientNetworkWriteFailure(e);
+
+                if (attempt == maxAttempts || (!promptTooLong && !transientNetworkWriteFailure)) {
                     throw e;
                 }
-                log.warn("AgentLoop: AI call failed with prompt-too-long error on attempt {}/{}. "
-                        + "Aggressively compacting history and retrying. Error: {}",
-                        attempt, maxRetries, e.getMessage());
-                // Aggressive compaction: keep only the last 2 compaction units
-                compactor.compactAggressively(history);
+
+                if (promptTooLong) {
+                    log.warn("AgentLoop: AI call failed with prompt-too-long error on attempt {}/{}. "
+                            + "Aggressively compacting history and retrying. Error: {}",
+                            attempt, maxAttempts, e.getMessage());
+                    // Aggressive compaction: keep only the last 2 compaction units
+                    compactor.compactAggressively(history);
+                } else {
+                    log.warn("AgentLoop: AI call failed with a transient network write error on attempt {}/{}. "
+                            + "Retrying without changing history. Error: {}",
+                            attempt, maxAttempts, e.getMessage());
+                }
             }
         }
         // Unreachable, but keeps the compiler happy
         throw new IllegalStateException("callAiWithRetry: exceeded max retries");
     }
-}
 
+    static boolean isTransientNetworkWriteFailure(Throwable error) {
+        Throwable current = error;
+        while (current != null) {
+            if (current instanceof SocketException) {
+                String message = current.getMessage();
+                if (message != null) {
+                    String normalized = message.toLowerCase(Locale.ROOT);
+                    if (normalized.contains("broken pipe")
+                            || normalized.contains("connection reset")
+                            || normalized.contains("connection aborted")) {
+                        return true;
+                    }
+                }
+            }
+
+            Throwable cause = current.getCause();
+            if (cause == current) {
+                break;
+            }
+            current = cause;
+        }
+        return false;
+    }
+}

--- a/src/test/java/org/remus/giteabot/agent/loop/AgentLoopTest.java
+++ b/src/test/java/org/remus/giteabot/agent/loop/AgentLoopTest.java
@@ -10,12 +10,15 @@ import org.remus.giteabot.agent.session.AgentSessionService;
 import org.remus.giteabot.agent.session.PendingMessage;
 import org.remus.giteabot.ai.AiClient;
 import org.remus.giteabot.ai.AiMessage;
+import org.springframework.http.converter.HttpMessageNotWritableException;
 
+import java.net.SocketException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 /**
@@ -175,6 +178,60 @@ class AgentLoopTest {
         assertThat(outcome.selectedBranch()).isEqualTo("dead-branch");
         verify(aiClient, times(2)).chat(anyList(), anyString(), anyString(), isNull(), anyInt());
     }
+
+    @Test
+    void run_brokenPipeDuringAiRequest_retriesOnceAndSucceeds() {
+        AgentLoop loop = new AgentLoop(aiClient, sessionService,
+                new AgentBudget(5, 3, 3, 8000,
+                        8_000, 120_000,
+                        200_000, 0.7));
+        HttpMessageNotWritableException brokenPipe = new HttpMessageNotWritableException(
+                "Could not write JSON", new SocketException("Broken pipe"));
+        when(aiClient.chat(anyList(), anyString(), anyString(), isNull(), anyInt()))
+                .thenThrow(brokenPipe)
+                .thenReturn("ai-final");
+
+        LoopOutcome outcome = loop.run(ctx, "go", finishingStrategy());
+
+        assertThat(outcome.success()).isTrue();
+        verify(aiClient, times(2)).chat(anyList(), eq("go"), eq("sys"), isNull(), eq(8000));
+    }
+
+    @Test
+    void run_nonNetworkSerializationFailure_doesNotRetry() {
+        AgentLoop loop = new AgentLoop(aiClient, sessionService,
+                new AgentBudget(5, 3, 3, 8000,
+                        8_000, 120_000,
+                        200_000, 0.7));
+        HttpMessageNotWritableException serializationFailure =
+                new HttpMessageNotWritableException("Could not write JSON");
+        when(aiClient.chat(anyList(), anyString(), anyString(), isNull(), anyInt()))
+                .thenThrow(serializationFailure);
+
+        assertThatThrownBy(() -> loop.run(ctx, "go", finishingStrategy()))
+                .isSameAs(serializationFailure);
+        verify(aiClient, times(1)).chat(anyList(), anyString(), anyString(), isNull(), anyInt());
+    }
+
+    @Test
+    void transientNetworkWriteFailure_requiresKnownSocketFailure() {
+        assertThat(AgentLoop.isTransientNetworkWriteFailure(
+                new RuntimeException(new SocketException("Connection reset by peer")))).isTrue();
+        assertThat(AgentLoop.isTransientNetworkWriteFailure(
+                new RuntimeException(new SocketException("Permission denied")))).isFalse();
+        assertThat(AgentLoop.isTransientNetworkWriteFailure(
+                new RuntimeException("broken pipe"))).isFalse();
+    }
+
+    private static AgentStrategy finishingStrategy() {
+        return new AgentStrategy() {
+            @Override public String systemPrompt() { return "sys"; }
+            @Override public StepDecision step(AgentRunContext c, String r, int round) {
+                return new StepDecision.Finish(LoopOutcome.success(c.baseBranch(), r));
+            }
+            @Override public LoopOutcome onBudgetExhausted(AgentRunContext c) {
+                throw new AssertionError("budget should not be exhausted");
+            }
+        };
+    }
 }
-
-


### PR DESCRIPTION
## What has been done?

- Extended the existing bounded AI-call retry path to recognize transient socket write failures by walking the exception cause chain.
- Retry only known `SocketException` conditions (`broken pipe`, `connection reset`, and `connection aborted`) once, without compacting or mutating conversation history.
- Preserve the existing prompt-too-long compaction retry and immediately rethrow unrelated serialization/runtime failures.
- Added tests for a successful broken-pipe retry, a non-network serialization failure, and positive/negative socket classification.

## Why?

A short-lived connection failure can surface through Spring as `HttpMessageNotWritableException` while the real cause is a nested `SocketException`. The previous code only caught `HttpClientErrorException`, so a `Broken pipe` aborted the entire agentic review even though one bounded retry could recover. This fixes #369 without broadly retrying deterministic JSON serialization errors.

## What has been tested?

- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home mvn -Denforcer.skip=true -Dtest=AgentLoopTest test` — 7 tests passed.
- `git diff --check` — passed.
- The full suite was also attempted on macOS with the OS enforcer skipped: 1,545 tests ran; the remaining 8 failures were locale-dependent English UI assertions under a Chinese locale, and 2 errors were Linux-only process-group tests. The repository intentionally enforces Linux for the complete build, so the upstream Linux CI is the authoritative full-suite verification.

## How AI was used?

OpenAI Codex was used to inspect the issue and current retry implementation, draft the narrow cause-chain classifier and tests, and run local verification. The contribution was constrained to the reported failure mode, reviewed against the repository conventions, and the platform-specific test limitations are documented above.