### PR TITLE
feat(ai): stream responses from Ollama and llama.cpp to fix read time…

### DIFF
--- a/src/main/java/org/remus/giteabot/agent/loop/AgentLoop.java
+++ b/src/main/java/org/remus/giteabot/agent/loop/AgentLoop.java
@@ -9,8 +9,10 @@ import org.remus.giteabot.ai.AiMessage;
 import org.remus.giteabot.ai.ChatTurn;
 import org.remus.giteabot.ai.ToolDescriptor;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
 
 import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -332,8 +334,12 @@ public final class AgentLoop {
      * When the provider rejects the request because the prompt exceeds its
      * context window, this method aggressively compacts the in-memory history
      * (keeping only the last 2 compaction units) and retries once.
-     * Transient socket write failures, such as a broken pipe or connection
-     * reset, are also retried once without modifying the conversation.
+     * Transient network failures are also retried once without modifying the
+     * conversation: socket write failures (broken pipe, connection reset,
+     * connection aborted) and streaming transport failures wrapped in
+     * {@link ResourceAccessException} (read timeout, mid-stream connection
+     * drop, malformed stream line — see {@link
+     * org.remus.giteabot.ai.StreamingLineReader}).
      *
      * <p>All other failures, and any failure on the second attempt, are
      * re-thrown to the caller.</p>
@@ -358,9 +364,9 @@ public final class AgentLoop {
             } catch (RuntimeException e) {
                 boolean promptTooLong = e instanceof HttpClientErrorException clientError
                         && aiClient.isPromptTooLongError(clientError);
-                boolean transientNetworkWriteFailure = isTransientNetworkWriteFailure(e);
+                boolean transientNetworkFailure = isTransientNetworkFailure(e);
 
-                if (attempt == maxAttempts || (!promptTooLong && !transientNetworkWriteFailure)) {
+                if (attempt == maxAttempts || (!promptTooLong && !transientNetworkFailure)) {
                     throw e;
                 }
 
@@ -371,7 +377,7 @@ public final class AgentLoop {
                     // Aggressive compaction: keep only the last 2 compaction units
                     compactor.compactAggressively(history);
                 } else {
-                    log.warn("AgentLoop: AI call failed with a transient network write error on attempt {}/{}. "
+                    log.warn("AgentLoop: AI call failed with a transient network error on attempt {}/{}. "
                             + "Retrying without changing history. Error: {}",
                             attempt, maxAttempts, e.getMessage());
                 }
@@ -381,18 +387,32 @@ public final class AgentLoop {
         throw new IllegalStateException("callAiWithRetry: exceeded max retries");
     }
 
-    static boolean isTransientNetworkWriteFailure(Throwable error) {
+    static boolean isTransientNetworkFailure(Throwable error) {
         Throwable current = error;
         while (current != null) {
-            if (current instanceof SocketException) {
-                String message = current.getMessage();
-                if (message != null) {
-                    String normalized = message.toLowerCase(Locale.ROOT);
-                    if (normalized.contains("broken pipe")
-                            || normalized.contains("connection reset")
-                            || normalized.contains("connection aborted")) {
-                        return true;
+            // Streaming transport failures surface as ResourceAccessException
+            // (read timeout / mid-stream drop / malformed line — see
+            // StreamingLineReader); a retry is the intended recovery, so treat
+            // the whole family as transient rather than matching the message.
+            switch (current) {
+                case ResourceAccessException resourceAccessException -> {
+                    return true;
+                }
+                case SocketTimeoutException socketTimeoutException -> {
+                    return true;
+                }
+                case SocketException socketException -> {
+                    String message = current.getMessage();
+                    if (message != null) {
+                        String normalized = message.toLowerCase(Locale.ROOT);
+                        if (normalized.contains("broken pipe")
+                                || normalized.contains("connection reset")
+                                || normalized.contains("connection aborted")) {
+                            return true;
+                        }
                     }
+                }
+                default -> {
                 }
             }
 

--- a/src/main/java/org/remus/giteabot/ai/AiClient.java
+++ b/src/main/java/org/remus/giteabot/ai/AiClient.java
@@ -98,6 +98,9 @@ public interface AiClient {
      */
     default boolean isPromptTooLongError(HttpClientErrorException e) {
         String body = e.getResponseBodyAsString();
+        if (body == null) {
+            return false;
+        }
         String normalized = body.toLowerCase(Locale.ROOT);
         String status = String.valueOf(e.getStatusCode().value());
         return normalized.contains("prompt is too long")

--- a/src/main/java/org/remus/giteabot/ai/StreamingLineReader.java
+++ b/src/main/java/org/remus/giteabot/ai/StreamingLineReader.java
@@ -1,0 +1,109 @@
+package org.remus.giteabot.ai;
+
+import org.springframework.http.HttpStatusCode;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Consumer;
+
+/**
+ * Shared line-oriented streaming transport for local-provider AI clients
+ * (Ollama, llama.cpp).
+ *
+ * <p>Posts a request body and reads the streaming response line by line,
+ * handing every non-blank line to a consumer. Reading line by line keeps
+ * {@code spring.http.clients.read-timeout} acting as a <em>per-chunk stall
+ * detector</em> rather than a whole-request budget: each socket read is bounded
+ * by the timeout, so a slow-but-alive model (chunks keep arriving within the
+ * window) never trips it, while a genuinely wedged server (no byte for the whole
+ * window) still fails fast. This fixes the intermittent "Read timed out"
+ * failures on local Ollama / llama.cpp, where a non-streamed request blocks the
+ * socket until the entire generation — model load + prompt eval + token
+ * generation — completes.</p>
+ *
+ * <p>The helper is format-agnostic: it only strips line terminators and skips
+ * blank lines. The consumer is responsible for any framing it needs — Ollama
+ * emits NDJSON (one JSON object per line) and llama.cpp's {@code /completion}
+ * with {@code stream:true} emits SSE ({@code data: {json}} per chunk) — and for
+ * parsing / reassembling the chunks into the provider-specific response DTO.</p>
+ *
+ * <p>Notes:</p>
+ * <ul>
+ *   <li>Model-load time still counts against the read timeout: Ollama emits no
+ *       chunks while loading, so a load longer than the timeout still trips it.
+ *       That is expected and documented; streaming removes the timeout pressure
+ *       for the (much larger) prompt-eval + generation phases.</li>
+ *   <li>I/O failures mid-stream (connection drop, read timeout) surface as
+ *       {@link ResourceAccessException}, which {@code AgentLoop.callAiWithRetry}
+ *       already treats as transient.</li>
+ *   <li>Malformed lines are surfaced to the consumer; the client fails the
+ *       request (does not silently skip) when a line does not parse.</li>
+ *   <li>No new dependencies: only the auto-configured {@link RestClient} and JDK.</li>
+ * </ul>
+ */
+public final class StreamingLineReader {
+
+    private StreamingLineReader() {
+        // utility class
+    }
+
+    /**
+     * POSTs {@code body} to {@code uri} (relative to the client's base URL) and
+     * streams the response, invoking {@code lineConsumer} for each non-blank
+     * line of the body.
+     *
+     * <p>The response is closed by the underlying {@link RestClient}
+     * {@code exchange} call after this method returns (or after an exception
+     * propagates), so callers do not need to close anything. The stream is
+     * drained fully (to EOF) before returning, which is also what keeps the
+     * per-read socket timeout active for the entire generation.</p>
+     *
+     * @param restClient   the configured client (base URL, headers, read timeout)
+     * @param uri          the endpoint, relative to the client's base URL
+     * @param body         the request payload
+     * @param lineConsumer receives each non-blank response line (may throw to
+     *                     fail the request, e.g. on a malformed line)
+     * @throws ResourceAccessException on I/O errors, including a read timeout
+     *         before or mid-stream
+     * @throws org.springframework.web.client.HttpClientErrorException on 4xx
+     * @throws org.springframework.web.client.HttpServerErrorException on 5xx
+     */
+    public static void streamLines(RestClient restClient, String uri, Object body,
+                                   Consumer<String> lineConsumer) {
+        restClient.post()
+                .uri(uri)
+                .body(body)
+                .exchange((request, response) -> {
+                    // getStatusCode() / getBody() throw IOException on I/O
+                    // trouble; Spring's exchange wrapper converts those to a
+                    // ResourceAccessException, so we let them propagate.
+                    HttpStatusCode status = response.getStatusCode();
+                    if (status.isError()) {
+                        // createException() builds the correct
+                        // HttpClientErrorException / HttpServerErrorException from
+                        // the status + body. It is a RuntimeException, so Spring
+                        // rethrows it as-is (not wrapped in ResourceAccessException).
+                        throw response.createException();
+                    }
+                    InputStream raw = response.getBody();
+                    // No try-with-resources: the underlying InputStream is the
+                    // response body, which the exchange call closes in its own
+                    // finally block (single close). Reading to EOF (readLine()
+                    // returns null) or throwing (mid-stream error) both leave the
+                    // socket to that finally close.
+                    BufferedReader reader = new BufferedReader(
+                            new InputStreamReader(raw, StandardCharsets.UTF_8));
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        if (!line.isEmpty()) {
+                            lineConsumer.accept(line);
+                        }
+                    }
+                    return null;
+                }, true);
+    }
+}

--- a/src/main/java/org/remus/giteabot/ai/llamacpp/LlamaCppClient.java
+++ b/src/main/java/org/remus/giteabot/ai/llamacpp/LlamaCppClient.java
@@ -1,11 +1,17 @@
 package org.remus.giteabot.ai.llamacpp;
 
 import lombok.extern.slf4j.Slf4j;
+import org.remus.giteabot.agent.shared.AgentJackson;
 import org.remus.giteabot.ai.AbstractAiClient;
 import org.remus.giteabot.ai.AiMessage;
+import org.remus.giteabot.ai.StreamingLineReader;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 
@@ -22,6 +28,8 @@ import java.util.Locale;
 public class LlamaCppClient extends AbstractAiClient {
 
     private final RestClient restClient;
+
+    private final ObjectMapper jackson = AgentJackson.mapper();
 
     /**
      * GBNF grammar for the agent's JSON response format.
@@ -78,9 +86,6 @@ public class LlamaCppClient extends AbstractAiClient {
     @Override
     public boolean isPromptTooLongError(HttpClientErrorException e) {
         String body = e.getResponseBodyAsString();
-        if (body == null) {
-            return false;
-        }
         String normalized = body.toLowerCase(Locale.ROOT);
         return normalized.contains("context length")
                 || normalized.contains("too long")
@@ -134,7 +139,7 @@ public class LlamaCppClient extends AbstractAiClient {
         LlamaCppRequest.LlamaCppRequestBuilder requestBuilder = LlamaCppRequest.builder()
                 .prompt(prompt)
                 .nPredict(maxTokens)
-                .stream(false)
+                .stream(true)
                 .stop(STOP_SEQUENCES)
                 .temperature(0.7)
                 .topP(0.9)
@@ -160,11 +165,67 @@ public class LlamaCppClient extends AbstractAiClient {
     }
 
     private LlamaCppResponse executeRequest(LlamaCppRequest request) {
-        return restClient.post()
-                .uri("/completion")
-                .body(request)
-                .retrieve()
-                .body(LlamaCppResponse.class);
+        // Stream the SSE chunks and reassemble them into a single response.
+        // llama.cpp /completion with stream:true emits "data: {json}" per chunk
+        // (an optional trailing "data: [DONE]" marker terminates the stream).
+        // Content is concatenated across chunks; tokens_evaluated /
+        // tokens_predicted / stopped_limit / timings come from the final chunk
+        // (stop:true), which is the only one carrying the usage counters — so
+        // audit/usage totals are unchanged from the non-streamed path.
+        StringBuilder content = new StringBuilder();
+        LlamaCppResponse[] finalRef = new LlamaCppResponse[1];
+        LlamaCppResponse[] lastRef = new LlamaCppResponse[1];
+
+        StreamingLineReader.streamLines(restClient, "/completion", request, line -> {
+            // Strip the SSE "data: " framing (the line reader already dropped
+            // line terminators and blank lines).
+            String json = line.startsWith("data:") ? line.substring(5).stripLeading() : line;
+            if (json.isEmpty() || "[DONE]".equals(json)) {
+                return;
+            }
+            LlamaCppResponse chunk;
+            try {
+                chunk = jackson.readValue(json, LlamaCppResponse.class);
+            } catch (JacksonException e) {
+                // A malformed SSE line fails the request (do not silently skip).
+                // Surfaced as an I/O error so AgentLoop.callAiWithRetry retries it
+                // like any transient failure.
+                throw new ResourceAccessException(
+                        "Malformed llama.cpp stream line: " + e.getMessage(), new IOException(e));
+            }
+            lastRef[0] = chunk;
+            if (chunk.getContent() != null) {
+                content.append(chunk.getContent());
+            }
+            // llama.cpp marks the final chunk with stop:true; it also carries the
+            // usage counters and timings.
+            if ("true".equals(chunk.getStop())) {
+                finalRef[0] = chunk;
+            }
+        });
+
+        // 0-chunk stream: reproduce the old empty-response path (body() used to
+        // return null for an empty body), so extractText applies its existing
+        // "Unable to generate ... empty response" fallback.
+        LlamaCppResponse source = finalRef[0] != null ? finalRef[0] : lastRef[0];
+        if (source == null) {
+            return null;
+        }
+
+        LlamaCppResponse merged = new LlamaCppResponse();
+        merged.setContent(!content.isEmpty()
+                ? content.toString()
+                : (source.getContent() != null ? source.getContent() : ""));
+        merged.setModel(source.getModel());
+        merged.setStop(source.getStop());
+        merged.setStoppedEos(source.getStoppedEos());
+        merged.setStoppedLimit(source.getStoppedLimit());
+        merged.setStoppedWord(source.getStoppedWord());
+        merged.setTokensEvaluated(source.getTokensEvaluated());
+        merged.setTokensPredicted(source.getTokensPredicted());
+        merged.setTruncated(source.getTruncated());
+        merged.setTimings(source.getTimings());
+        return merged;
     }
 
     private String extractText(LlamaCppRequest request, LlamaCppResponse response, String context) {

--- a/src/main/java/org/remus/giteabot/ai/llamacpp/LlamaCppClient.java
+++ b/src/main/java/org/remus/giteabot/ai/llamacpp/LlamaCppClient.java
@@ -86,6 +86,9 @@ public class LlamaCppClient extends AbstractAiClient {
     @Override
     public boolean isPromptTooLongError(HttpClientErrorException e) {
         String body = e.getResponseBodyAsString();
+        if (body == null) {
+            return false;
+        }
         String normalized = body.toLowerCase(Locale.ROOT);
         return normalized.contains("context length")
                 || normalized.contains("too long")

--- a/src/main/java/org/remus/giteabot/ai/ollama/OllamaClient.java
+++ b/src/main/java/org/remus/giteabot/ai/ollama/OllamaClient.java
@@ -117,6 +117,9 @@ public class OllamaClient extends AbstractAiClient {
     @Override
     public boolean isPromptTooLongError(HttpClientErrorException e) {
         String body = e.getResponseBodyAsString();
+        if (body == null) {
+            return false;
+        }
         String normalized = body.toLowerCase(Locale.ROOT);
         return normalized.contains("too long") || normalized.contains("context length");
     }
@@ -276,9 +279,12 @@ public class OllamaClient extends AbstractAiClient {
         // concatenated across chunks; done_reason / prompt_eval_count / eval_count
         // (and tool_calls) come from the final (done:true) chunk, which is the only
         // one that carries the usage counters — so audit/usage totals are unchanged
-        // from the non-streamed path.
+        // from the non-streamed path. If the stream ends without a done chunk
+        // (e.g. provider/proxy truncation), the last chunk is used as the
+        // metadata fallback, so model metadata is not lost.
         StringBuilder content = new StringBuilder();
         OllamaResponse[] finalRef = new OllamaResponse[1];
+        OllamaResponse[] lastRef = new OllamaResponse[1];
 
         StreamingLineReader.streamLines(restClient, "/api/chat", request, line -> {
             OllamaResponse chunk;
@@ -291,6 +297,7 @@ public class OllamaClient extends AbstractAiClient {
                 throw new ResourceAccessException(
                         "Malformed Ollama stream line: " + e.getMessage(), new IOException(e));
             }
+            lastRef[0] = chunk;
             if (chunk.getMessage() != null && chunk.getMessage().getContent() != null) {
                 content.append(chunk.getMessage().getContent());
             }
@@ -302,33 +309,31 @@ public class OllamaClient extends AbstractAiClient {
         // 0-chunk stream: reproduce the old empty-response path (body() used to
         // return null for an empty body), so extractText / interpret apply their
         // existing "Unable to generate ... empty response" fallback.
-        if (content.isEmpty() && finalRef[0] == null) {
+        OllamaResponse source = finalRef[0] != null ? finalRef[0] : lastRef[0];
+        if (source == null) {
             return null;
         }
 
         OllamaResponse merged = new OllamaResponse();
         String mergedContent = !content.isEmpty()
                 ? content.toString()
-                : (finalRef[0] != null && finalRef[0].getMessage() != null
-                    && finalRef[0].getMessage().getContent() != null
-                    ? finalRef[0].getMessage().getContent()
+                : (source.getMessage() != null && source.getMessage().getContent() != null
+                    ? source.getMessage().getContent()
                     : "");
         OllamaResponse.Message message = new OllamaResponse.Message();
         message.setRole("assistant");
         message.setContent(mergedContent);
-        if (finalRef[0] != null) {
-            merged.setDone(true);
-            merged.setDoneReason(finalRef[0].getDoneReason());
-            merged.setPromptEvalCount(finalRef[0].getPromptEvalCount());
-            merged.setEvalCount(finalRef[0].getEvalCount());
-            merged.setTotalDuration(finalRef[0].getTotalDuration());
-            if (finalRef[0].getModel() != null) {
-                merged.setModel(finalRef[0].getModel());
-            }
-            if (finalRef[0].getMessage() != null) {
-                // Tool calls are emitted complete in the final chunk.
-                message.setToolCalls(finalRef[0].getMessage().getToolCalls());
-            }
+        merged.setDone(finalRef[0] != null);
+        merged.setDoneReason(source.getDoneReason());
+        merged.setPromptEvalCount(source.getPromptEvalCount());
+        merged.setEvalCount(source.getEvalCount());
+        merged.setTotalDuration(source.getTotalDuration());
+        if (source.getModel() != null) {
+            merged.setModel(source.getModel());
+        }
+        if (source.getMessage() != null) {
+            // Tool calls are emitted complete in the final chunk.
+            message.setToolCalls(source.getMessage().getToolCalls());
         }
         merged.setMessage(message);
         return merged;

--- a/src/main/java/org/remus/giteabot/ai/ollama/OllamaClient.java
+++ b/src/main/java/org/remus/giteabot/ai/ollama/OllamaClient.java
@@ -7,14 +7,18 @@ import org.remus.giteabot.ai.AiClientDelegateSupport;
 import org.remus.giteabot.ai.AiMessage;
 import org.remus.giteabot.ai.ChatTurn;
 import org.remus.giteabot.ai.StopReason;
+import org.remus.giteabot.ai.StreamingLineReader;
 import org.remus.giteabot.ai.ToolCall;
 import org.remus.giteabot.ai.ToolDescriptor;
 import org.remus.giteabot.ai.ToolNameSanitizer;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
+import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -98,7 +102,7 @@ public class OllamaClient extends AbstractAiClient {
         OllamaRequest request = OllamaRequest.builder()
                 .model(effectiveModel)
                 .messages(messages)
-                .stream(false)
+                .stream(true)
                 .options(OllamaRequest.Options.builder().numPredict(effectiveMaxTokens).build())
                 .tools(toolPayloads)
                 .build();
@@ -247,7 +251,7 @@ public class OllamaClient extends AbstractAiClient {
         OllamaRequest.OllamaRequestBuilder requestBuilder = OllamaRequest.builder()
                 .model(model)
                 .messages(messages)
-                .stream(false)
+                .stream(true)
                 .options(OllamaRequest.Options.builder()
                         .numPredict(maxTokens)
                         .build());
@@ -267,11 +271,67 @@ public class OllamaClient extends AbstractAiClient {
     }
 
     private OllamaResponse executeRequest(OllamaRequest request) {
-        return restClient.post()
-                .uri("/api/chat")
-                .body(request)
-                .retrieve()
-                .body(OllamaResponse.class);
+        // Stream the NDJSON chunks and reassemble them into a single response.
+        // Each line is a complete OllamaResponse-shaped JSON object. Content is
+        // concatenated across chunks; done_reason / prompt_eval_count / eval_count
+        // (and tool_calls) come from the final (done:true) chunk, which is the only
+        // one that carries the usage counters — so audit/usage totals are unchanged
+        // from the non-streamed path.
+        StringBuilder content = new StringBuilder();
+        OllamaResponse[] finalRef = new OllamaResponse[1];
+
+        StreamingLineReader.streamLines(restClient, "/api/chat", request, line -> {
+            OllamaResponse chunk;
+            try {
+                chunk = jackson.readValue(line, OllamaResponse.class);
+            } catch (JacksonException e) {
+                // A malformed NDJSON line fails the request (do not silently skip).
+                // Surfaced as an I/O error so AgentLoop.callAiWithRetry retries it
+                // like any transient failure.
+                throw new ResourceAccessException(
+                        "Malformed Ollama stream line: " + e.getMessage(), new IOException(e));
+            }
+            if (chunk.getMessage() != null && chunk.getMessage().getContent() != null) {
+                content.append(chunk.getMessage().getContent());
+            }
+            if (chunk.isDone()) {
+                finalRef[0] = chunk;
+            }
+        });
+
+        // 0-chunk stream: reproduce the old empty-response path (body() used to
+        // return null for an empty body), so extractText / interpret apply their
+        // existing "Unable to generate ... empty response" fallback.
+        if (content.isEmpty() && finalRef[0] == null) {
+            return null;
+        }
+
+        OllamaResponse merged = new OllamaResponse();
+        String mergedContent = !content.isEmpty()
+                ? content.toString()
+                : (finalRef[0] != null && finalRef[0].getMessage() != null
+                    && finalRef[0].getMessage().getContent() != null
+                    ? finalRef[0].getMessage().getContent()
+                    : "");
+        OllamaResponse.Message message = new OllamaResponse.Message();
+        message.setRole("assistant");
+        message.setContent(mergedContent);
+        if (finalRef[0] != null) {
+            merged.setDone(true);
+            merged.setDoneReason(finalRef[0].getDoneReason());
+            merged.setPromptEvalCount(finalRef[0].getPromptEvalCount());
+            merged.setEvalCount(finalRef[0].getEvalCount());
+            merged.setTotalDuration(finalRef[0].getTotalDuration());
+            if (finalRef[0].getModel() != null) {
+                merged.setModel(finalRef[0].getModel());
+            }
+            if (finalRef[0].getMessage() != null) {
+                // Tool calls are emitted complete in the final chunk.
+                message.setToolCalls(finalRef[0].getMessage().getToolCalls());
+            }
+        }
+        merged.setMessage(message);
+        return merged;
     }
 
     private String extractText(OllamaRequest request, OllamaResponse response, String context) {

--- a/src/main/java/org/remus/giteabot/ai/openai/OpenAiClient.java
+++ b/src/main/java/org/remus/giteabot/ai/openai/OpenAiClient.java
@@ -105,6 +105,9 @@ public class OpenAiClient extends AbstractAiClient {
     @Override
     public boolean isPromptTooLongError(HttpClientErrorException e) {
         String body = e.getResponseBodyAsString();
+        if (body == null) {
+            return false;
+        }
         String normalized = body.toLowerCase(Locale.ROOT);
         return normalized.contains("maximum context length")
                 || normalized.contains("too many tokens")

--- a/src/test/java/org/remus/giteabot/admin/OllamaReadTimeoutIT.java
+++ b/src/test/java/org/remus/giteabot/admin/OllamaReadTimeoutIT.java
@@ -1,0 +1,105 @@
+package org.remus.giteabot.admin;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.remus.giteabot.ai.AiProviderRegistry;
+import org.remus.giteabot.aiusage.AiUsageService;
+import org.remus.giteabot.config.AiUsageProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.client.ResourceAccessException;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Proves that {@code spring.http.clients.read-timeout} actually applies to the
+ * Ollama AI client built through {@link AiClientFactory}: a server that delays
+ * its response beyond the configured timeout must produce a read-timeout error
+ * (not just hang).
+ */
+@SpringBootTest
+@TestPropertySource(properties = "spring.http.clients.read-timeout=2s")
+class OllamaReadTimeoutIT {
+
+    @Autowired
+    private AiClientFactory aiClientFactory;
+
+    @Autowired
+    private AiProviderRegistry providerRegistry;
+
+    @Autowired
+    private AiIntegrationService aiIntegrationService;
+
+    @Autowired
+    private AiUsageService aiUsageService;
+
+    @Autowired
+    private AiUsageProperties usageProperties;
+
+    private HttpServer server;
+
+    @BeforeEach
+    void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/api/chat", exchange -> {
+            try {
+                // Delay well beyond the 2s read timeout before responding.
+                Thread.sleep(10_000);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+            byte[] body = "{\"message\":{\"role\":\"assistant\",\"content\":\"ok\"},"
+                    .getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(body);
+            }
+        });
+        server.setExecutor(Executors.newCachedThreadPool());
+        server.start();
+    }
+
+    @AfterEach
+    void stopServer() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void ollamaClientHonoursConfiguredReadTimeout() {
+        AiIntegration integration = new AiIntegration();
+        integration.setId(987654L);
+        integration.setName("timeout-test");
+        integration.setProviderType("ollama");
+        integration.setApiUrl("http://localhost:" + server.getAddress().getPort());
+        integration.setModel("test-model");
+        integration.setMaxTokens(128);
+        integration.setCreatedAt(java.time.Instant.now());
+        integration.setUpdatedAt(java.time.Instant.now());
+
+        AiClientFactory factory = new AiClientFactory(aiIntegrationService, providerRegistry,
+                aiUsageService, usageProperties);
+
+        long start = System.nanoTime();
+        ResourceAccessException ex = assertThrows(ResourceAccessException.class,
+                () -> factory.getClient(integration).submitReviewPrompt("system", null, "user"));
+        long elapsedMillis = (System.nanoTime() - start) / 1_000_000;
+
+        assertTrue(elapsedMillis < 9_000,
+                "request should have timed out around 2s, took " + elapsedMillis + "ms");
+        assertTrue(String.valueOf(ex.getMessage()).toLowerCase().contains("timed out")
+                        || ex.getCause() instanceof java.net.SocketTimeoutException,
+                "expected a read timeout, got: " + ex);
+    }
+}

--- a/src/test/java/org/remus/giteabot/admin/OllamaReadTimeoutIT.java
+++ b/src/test/java/org/remus/giteabot/admin/OllamaReadTimeoutIT.java
@@ -58,7 +58,9 @@ class OllamaReadTimeoutIT {
             } catch (InterruptedException ignored) {
                 Thread.currentThread().interrupt();
             }
-            byte[] body = "{\"message\":{\"role\":\"assistant\",\"content\":\"ok\"},"
+            byte[] body = ("{\"model\":\"test-model\",\"created_at\":\"2026-01-01T00:00:00Z\","
+                    + "\"message\":{\"role\":\"assistant\",\"content\":\"ok\"},\"done\":true,"
+                    + "\"done_reason\":\"stop\",\"prompt_eval_count\":1,\"eval_count\":1}")
                     .getBytes(StandardCharsets.UTF_8);
             exchange.sendResponseHeaders(200, body.length);
             try (OutputStream os = exchange.getResponseBody()) {

--- a/src/test/java/org/remus/giteabot/agent/loop/AgentLoopTest.java
+++ b/src/test/java/org/remus/giteabot/agent/loop/AgentLoopTest.java
@@ -11,6 +11,7 @@ import org.remus.giteabot.agent.session.PendingMessage;
 import org.remus.giteabot.ai.AiClient;
 import org.remus.giteabot.ai.AiMessage;
 import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.web.client.ResourceAccessException;
 
 import java.net.SocketException;
 import java.nio.file.Path;
@@ -31,12 +32,11 @@ class AgentLoopTest {
     @Mock private AiClient aiClient;
     @Mock private AgentSessionService sessionService;
 
-    private AgentSession session;
     private AgentRunContext ctx;
 
     @BeforeEach
     void setUp() {
-        session = new AgentSession("owner", "repo", 42L, "title");
+        AgentSession session = new AgentSession("owner", "repo", 42L, "title");
         session.setId(1L); // persisted session — the loop flushes id-bearing sessions
         ctx = new AgentRunContext(session, "owner", "repo", 42L, Path.of("/tmp/ws"), "main");
         // lenient: the transient-session test below uses its own id-less session.
@@ -136,7 +136,7 @@ class AgentLoopTest {
 
         // First call: empty history, user="kickoff"
         assertThat(historySnapshots.get(0)).isEmpty();
-        assertThat(userMessages.get(0)).isEqualTo("kickoff");
+        assertThat(userMessages.getFirst()).isEqualTo("kickoff");
         // Second call: history contains the kickoff/first-ai pair, user="follow-up-prompt"
         assertThat(historySnapshots.get(1)).hasSize(2);
         assertThat(historySnapshots.get(1).get(0).getRole()).isEqualTo("user");
@@ -214,13 +214,28 @@ class AgentLoopTest {
     }
 
     @Test
-    void transientNetworkWriteFailure_requiresKnownSocketFailure() {
-        assertThat(AgentLoop.isTransientNetworkWriteFailure(
+    void transientNetworkFailure_requiresKnownNetworkFailure() {
+        assertThat(AgentLoop.isTransientNetworkFailure(
                 new RuntimeException(new SocketException("Connection reset by peer")))).isTrue();
-        assertThat(AgentLoop.isTransientNetworkWriteFailure(
+        assertThat(AgentLoop.isTransientNetworkFailure(
                 new RuntimeException(new SocketException("Permission denied")))).isFalse();
-        assertThat(AgentLoop.isTransientNetworkWriteFailure(
+        assertThat(AgentLoop.isTransientNetworkFailure(
                 new RuntimeException("broken pipe"))).isFalse();
+    }
+
+    @Test
+    void transientNetworkFailure_streamingTransportFailuresAreRetried() {
+        // A mid-stream read timeout (per-chunk stall detector) and a malformed
+        // stream line both surface as ResourceAccessException and must be
+        // retried, matching the streaming clients' contract.
+        assertThat(AgentLoop.isTransientNetworkFailure(
+                new ResourceAccessException("I/O error on POST request to \"/api/chat\": Read timed out",
+                        new java.net.SocketTimeoutException("Read timed out")))).isTrue();
+        assertThat(AgentLoop.isTransientNetworkFailure(
+                new ResourceAccessException("Malformed Ollama stream line: Unexpected token"))).isTrue();
+        assertThat(AgentLoop.isTransientNetworkFailure(
+                new ResourceAccessException("I/O error on POST request to \"/completion\": Connection reset",
+                        new java.net.SocketException("Connection reset")))).isTrue();
     }
 
     private static AgentStrategy finishingStrategy() {

--- a/src/test/java/org/remus/giteabot/ai/OllamaStreamingTimeoutIT.java
+++ b/src/test/java/org/remus/giteabot/ai/OllamaStreamingTimeoutIT.java
@@ -1,0 +1,222 @@
+package org.remus.giteabot.ai;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.remus.giteabot.ai.ollama.OllamaClient;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration test for the streaming read-timeout behaviour of
+ * {@link OllamaClient}. It drives the real client (not a mock) against a JDK
+ * {@link HttpServer} stub with a real Apache-HttpComponents read timeout of 2s,
+ * mirroring how {@code spring.http.clients.read-timeout} is applied to the
+ * production client (Boot 4 {@code HttpClientSettings} → HC5 {@code setResponseTimeout}).
+ *
+ * <p>Proves the three timeout cases required by the streaming fix:
+ * <ul>
+ *   <li>AC 3 — slow-but-alive: total generation &gt; read timeout, but every
+ *       inter-chunk gap &lt; timeout → the request <em>completes</em> (the read
+ *       timeout is a per-chunk stall detector, not a whole-request budget).</li>
+ *   <li>AC 4 — silent mid-stream: chunks stop arriving → fails with
+ *       {@link ResourceAccessException}/{@link SocketTimeoutException} after ~
+ *       the read timeout.</li>
+ *   <li>Pre-first-chunk stall: no chunks emitted (model load) → same read-timeout
+ *       failure as before the streaming change (the load still counts against
+ *       the timeout — documented limitation).</li>
+ * </ul>
+ */
+class OllamaStreamingTimeoutIT {
+
+    private static final long READ_TIMEOUT_MS = 2000;
+
+    private HttpServer server;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.setExecutor(Executors.newCachedThreadPool());
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // helpers
+    // -----------------------------------------------------------------
+
+    private OllamaClient client() {
+        RequestConfig cfg = RequestConfig.custom()
+                .setConnectTimeout(2, TimeUnit.SECONDS)
+                .setConnectionRequestTimeout(2, TimeUnit.SECONDS)
+                .setResponseTimeout(READ_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                .build();
+        CloseableHttpClient hc = HttpClients.custom().setDefaultRequestConfig(cfg).build();
+        RestClient restClient = RestClient.builder()
+                .baseUrl("http://localhost:" + server.getAddress().getPort())
+                .requestFactory(new HttpComponentsClientHttpRequestFactory(hc))
+                .defaultHeader("Content-Type", "application/json")
+                .build();
+        return new OllamaClient(restClient, "test-model", 128, true);
+    }
+
+    private static void drain(HttpExchange exchange) throws IOException {
+        try (InputStream in = exchange.getRequestBody()) {
+            in.readAllBytes();
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // AC 3: slow-but-alive — total generation time exceeds the read timeout,
+    // but chunks keep arriving within the timeout window → completes.
+    // -----------------------------------------------------------------
+
+    @Test
+    void slowButAlive_totalGenerationExceedsTimeoutButChunksKeepFlowing_completes() {
+        // 6 chunks, first one quick, then a 1s gap between each (all gaps < 2s).
+        // Total ≈ 5s, which is well beyond the 2s read timeout. Because a byte
+        // arrives within the window on every read, no single read times out and
+        // the whole generation completes.
+        server.createContext("/api/chat", exchange -> {
+            try {
+                drain(exchange);
+                exchange.getResponseHeaders().set("Content-Type", "application/x-ndjson");
+                exchange.sendResponseHeaders(200, 0); // chunked
+                OutputStream os = exchange.getResponseBody();
+                int total = 6;
+                for (int i = 0; i < total; i++) {
+                    boolean done = (i == total - 1);
+                    String line = "{\"model\":\"m\",\"message\":{\"role\":\"assistant\","
+                            + "\"content\":\"w\"},"
+                            + (done
+                                ? "\"done\":true,\"done_reason\":\"stop\",\"prompt_eval_count\":16,\"eval_count\":42}"
+                                : "\"done\":false}");
+                    os.write(line.getBytes(StandardCharsets.UTF_8));
+                    os.write('\n');
+                    os.flush();
+                    if (!done) {
+                        Thread.sleep(1000); // gap < 2s read timeout
+                    }
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                exchange.close();
+            }
+        });
+        server.start();
+
+        long t0 = System.nanoTime();
+        String review = client().submitReviewPrompt("You are a code reviewer.", null, "review");
+        long elapsed = (System.nanoTime() - t0) / 1_000_000;
+
+        assertEquals("wwwwww", review, "merged content from all 6 chunks");
+        // Proves the request genuinely took longer than the read timeout yet
+        // still succeeded — the whole point of per-chunk stall detection.
+        assertTrue(elapsed >= READ_TIMEOUT_MS,
+                "expected total to exceed the " + READ_TIMEOUT_MS + "ms read timeout, took " + elapsed + "ms");
+    }
+
+    // -----------------------------------------------------------------
+    // AC 4: silent mid-stream — chunks stop arriving → read timeout ~2s.
+    // -----------------------------------------------------------------
+
+    @Test
+    void silentMidStream_failsWithResourceAccessExceptionAtReadTimeout() {
+        server.createContext("/api/chat", exchange -> {
+            try {
+                drain(exchange);
+                exchange.getResponseHeaders().set("Content-Type", "application/x-ndjson");
+                exchange.sendResponseHeaders(200, 0); // chunked
+                OutputStream os = exchange.getResponseBody();
+                os.write("{\"model\":\"m\",\"message\":{\"role\":\"assistant\",\"content\":\"a\"},\"done\":false}\n"
+                        .getBytes(StandardCharsets.UTF_8));
+                os.flush();
+                os.write("{\"model\":\"m\",\"message\":{\"role\":\"assistant\",\"content\":\"b\"},\"done\":false}\n"
+                        .getBytes(StandardCharsets.UTF_8));
+                os.flush();
+                // Now go completely silent (never close) → the next read blocks
+                // until the 2s read timeout fires.
+                Thread.sleep(20_000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                exchange.close();
+            }
+        });
+        server.start();
+
+        long t0 = System.nanoTime();
+        ResourceAccessException ex = assertThrows(ResourceAccessException.class,
+                () -> client().submitReviewPrompt("You are a code reviewer.", null, "review"));
+        long elapsed = (System.nanoTime() - t0) / 1_000_000;
+
+        assertTrue(elapsed < 9_000, "should fail near the 2s read timeout, took " + elapsed + "ms");
+        assertTrue(isReadTimeout(ex), "expected a read timeout, got: " + ex
+                + " (cause: " + ex.getCause() + ")");
+    }
+
+    // -----------------------------------------------------------------
+    // Pre-first-chunk stall: no chunks (model load) → read timeout ~2s.
+    // This preserves the behaviour of the pre-streaming OllamaReadTimeoutIT.
+    // -----------------------------------------------------------------
+
+    @Test
+    void silentBeforeFirstChunk_stillFailsAtReadTimeout() {
+        server.createContext("/api/chat", exchange -> {
+            try {
+                // Model load: emit nothing for a long time before the first
+                // chunk (or response). The read timeout still applies — this is
+                // the documented limitation of streaming (load time counts).
+                Thread.sleep(20_000);
+                exchange.sendResponseHeaders(200, 0); // too late
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                exchange.close();
+            }
+        });
+        server.start();
+
+        long t0 = System.nanoTime();
+        ResourceAccessException ex = assertThrows(ResourceAccessException.class,
+                () -> client().submitReviewPrompt("You are a code reviewer.", null, "review"));
+        long elapsed = (System.nanoTime() - t0) / 1_000_000;
+
+        assertTrue(elapsed < 9_000, "should fail near the 2s read timeout, took " + elapsed + "ms");
+        assertTrue(isReadTimeout(ex), "expected a read timeout, got: " + ex
+                + " (cause: " + ex.getCause() + ")");
+    }
+
+    private static boolean isReadTimeout(ResourceAccessException ex) {
+        if (ex.getCause() instanceof SocketTimeoutException) {
+            return true;
+        }
+        String msg = String.valueOf(ex.getMessage());
+        return msg != null && msg.toLowerCase().contains("timed out");
+    }
+}

--- a/src/test/java/org/remus/giteabot/ai/llamacpp/LlamaCppClientStreamingTest.java
+++ b/src/test/java/org/remus/giteabot/ai/llamacpp/LlamaCppClientStreamingTest.java
@@ -1,0 +1,243 @@
+package org.remus.giteabot.ai.llamacpp;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.remus.giteabot.ai.AiAuditRecorder;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Streaming merge behaviour of {@link LlamaCppClient}: it now sends
+ * {@code stream:true} to {@code /completion} and reassembles the SSE chunks
+ * ({@code data: {json}}) into a single {@link LlamaCppResponse}. These tests
+ * drive the real client against a JDK {@link HttpServer} stub that emits the
+ * same chunk sequence a live llama.cpp server produces.
+ */
+class LlamaCppClientStreamingTest {
+
+    private HttpServer server;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.setExecutor(Executors.newCachedThreadPool());
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // helpers
+    // -----------------------------------------------------------------
+
+    private static RestClient timedClient(int port, long readTimeoutMillis) {
+        RequestConfig cfg = RequestConfig.custom()
+                .setConnectTimeout(2, TimeUnit.SECONDS)
+                .setConnectionRequestTimeout(2, TimeUnit.SECONDS)
+                .setResponseTimeout(readTimeoutMillis, TimeUnit.MILLISECONDS)
+                .build();
+        CloseableHttpClient hc = HttpClients.custom().setDefaultRequestConfig(cfg).build();
+        return RestClient.builder()
+                .baseUrl("http://localhost:" + port)
+                .requestFactory(new HttpComponentsClientHttpRequestFactory(hc))
+                .defaultHeader("Content-Type", "application/json")
+                .build();
+    }
+
+    private LlamaCppClient client() {
+        return new LlamaCppClient(timedClient(server.getAddress().getPort(), 5000),
+                "qwen2.5-coder", 4096);
+    }
+
+    private static final class CapturingRecorder implements AiAuditRecorder {
+        long input = -1;
+        long output = -1;
+        long invocations = 0;
+
+        @Override
+        public void recordUsage(long inputTokens, long outputTokens,
+                                long cacheCreation, long cacheRead,
+                                String rawRequest, String rawResponse) {
+            this.input = inputTokens;
+            this.output = outputTokens;
+            this.invocations++;
+        }
+
+        @Override
+        public void recordError(Throwable error) {
+        }
+    }
+
+    private static void drain(HttpExchange exchange) throws IOException {
+        try (InputStream in = exchange.getRequestBody()) {
+            in.readAllBytes();
+        }
+    }
+
+    /** Escapes a Java string for embedding as a JSON string literal value. */
+    private static String j(String s) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '"' -> sb.append("\\\"");
+                case '\\' -> sb.append("\\\\");
+                case '\n' -> sb.append("\\n");
+                case '\r' -> sb.append("\\r");
+                case '\t' -> sb.append("\\t");
+                case '\b' -> sb.append("\\b");
+                case '\f' -> sb.append("\\f");
+                default -> {
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+                }
+            }
+        }
+        return sb.toString();
+    }
+
+    /** Emits SSE chunks: each {@code data: <json>}, then a terminating
+     *  {@code data: [DONE]} (both are valid llama.cpp stream framing). */
+    private void emitSse(String... jsonChunks) {
+        server.createContext("/completion", exchange -> {
+            try {
+                drain(exchange);
+                exchange.getResponseHeaders().set("Content-Type", "text/event-stream");
+                exchange.sendResponseHeaders(200, 0); // chunked
+                OutputStream os = exchange.getResponseBody();
+                for (String json : jsonChunks) {
+                    os.write(("data: " + json).getBytes(StandardCharsets.UTF_8));
+                    os.write('\n');
+                    os.flush();
+                }
+                // Optional terminal marker — the client must tolerate it.
+                os.write("data: [DONE]\n".getBytes(StandardCharsets.UTF_8));
+                os.flush();
+            } catch (IOException e) {
+                // best effort
+            } finally {
+                exchange.close();
+            }
+        });
+        server.start();
+    }
+
+    // -----------------------------------------------------------------
+    // AC 2: SSE merge — content concatenated, grammar output intact,
+    // usage counters + stoppedLimit from the final (stop:true) chunk.
+    // -----------------------------------------------------------------
+
+    @Test
+    void sseMerge_concatenatesGrammarJsonAndTakesCountersFromFinalChunk() throws Exception {
+        // A GBNF-constrained JSON response, split across chunks exactly as
+        // llama.cpp would emit it token by token, with the usage counters and
+        // stoppedLimit on the final chunk (stop:true).
+        String json = "{\"fileChanges\":[{\"file\":\"a.java\",\"content\":\"int x = 1;\"}],"
+                + "\"message\":\"looks good\",\"done\":true}";
+        // Split into a few pieces; the merge must reproduce the exact JSON.
+        String a = "{\"fileChanges\":[{\"file\":\"a.java\",\"cont";
+        String b = "ent\":\"int x = 1;\"}],\"message\":\"look";
+        String c = "s good\",\"done\":true}";
+
+        String mid1 = "{\"content\":\"" + j(a) + "\",\"model\":\"qwen\",\"stop\":false,"
+                + "\"stopped_eos\":false,\"stopped_limit\":false,\"stopped_word\":false,"
+                + "\"tokens_evaluated\":0,\"tokens_predicted\":0,\"truncated\":false}";
+        String mid2 = "{\"content\":\"" + j(b) + "\",\"model\":\"qwen\",\"stop\":false,"
+                + "\"stopped_eos\":false,\"stopped_limit\":false,\"stopped_word\":false,"
+                + "\"tokens_evaluated\":0,\"tokens_predicted\":0,\"truncated\":false}";
+        String fin = "{\"content\":\"" + j(c) + "\",\"model\":\"qwen\",\"stop\":true,"
+                + "\"stopped_eos\":false,\"stopped_limit\":true,\"stopped_word\":false,"
+                + "\"tokens_evaluated\":16,\"tokens_predicted\":491,\"truncated\":false,"
+                + "\"timings\":{\"prompt_n\":16,\"prompt_ms\":0.3,\"predicted_n\":491,\"predicted_ms\":20.3}}";
+
+        emitSse(mid1, mid2, fin);
+
+        CapturingRecorder recorder = new CapturingRecorder();
+        LlamaCppClient client = client();
+        client.setAuditRecorder(recorder);
+
+        String out = client.submitReviewPrompt("respond with a json", null, "review");
+
+        // The merged content must be the exact, grammar-constrained JSON (no
+        // framing leakage, no double-counted tokens).
+        assertEquals(json, out);
+        // Counters from the final chunk only.
+        assertEquals(16L, recorder.input);
+        assertEquals(491L, recorder.output);
+        assertEquals(1, recorder.invocations);
+    }
+
+    // -----------------------------------------------------------------
+    // AC 5 / edge case: per-chunk counters must not be summed.
+    // -----------------------------------------------------------------
+
+    @Test
+    void usageParity_recordsFinalChunkCountersNotASum() {
+        String mid1 = "{\"content\":\"a\",\"model\":\"m\",\"stop\":false,"
+                + "\"tokens_evaluated\":0,\"tokens_predicted\":7}";
+        String mid2 = "{\"content\":\"b\",\"model\":\"m\",\"stop\":false,"
+                + "\"tokens_evaluated\":0,\"tokens_predicted\":12}";
+        String fin = "{\"content\":\"\",\"model\":\"m\",\"stop\":true,"
+                + "\"stopped_limit\":false,\"tokens_evaluated\":22,\"tokens_predicted\":19}";
+
+        emitSse(mid1, mid2, fin);
+
+        CapturingRecorder recorder = new CapturingRecorder();
+        LlamaCppClient client = client();
+        client.setAuditRecorder(recorder);
+
+        String out = client.submitReviewPrompt("review", null, "hi");
+
+        assertEquals("ab", out);
+        // 19, not 7+12+19.
+        assertEquals(22L, recorder.input);
+        assertEquals(19L, recorder.output, "output tokens = final chunk tokens_predicted (not a sum)");
+    }
+
+    // -----------------------------------------------------------------
+    // edge case: empty stream (0 chunks) -> existing empty-response fallback.
+    // -----------------------------------------------------------------
+
+    @Test
+    void emptyStream_returnsExistingEmptyResponseFallback() {
+        server.createContext("/completion", exchange -> {
+            try {
+                drain(exchange);
+                exchange.sendResponseHeaders(200, 0); // empty 200, no body
+            } catch (IOException e) {
+                // best effort
+            } finally {
+                exchange.close();
+            }
+        });
+        server.start();
+
+        String out = client().submitReviewPrompt("review", null, "hi");
+        assertTrue(out.startsWith("Unable to generate review - empty response"),
+                "expected the historical empty-response fallback, got: " + out);
+    }
+}

--- a/src/test/java/org/remus/giteabot/ai/ollama/OllamaClientStreamingTest.java
+++ b/src/test/java/org/remus/giteabot/ai/ollama/OllamaClientStreamingTest.java
@@ -1,0 +1,249 @@
+package org.remus.giteabot.ai.ollama;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.remus.giteabot.ai.AiAuditRecorder;
+import org.remus.giteabot.ai.ChatTurn;
+import org.remus.giteabot.ai.StopReason;
+import org.remus.giteabot.ai.ToolCall;
+import org.remus.giteabot.ai.ToolDescriptor;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Streaming merge behaviour of {@link OllamaClient}: it now sends
+ * {@code stream:true} to {@code /api/chat} and reassembles the NDJSON chunks
+ * into a single {@link OllamaResponse}. These tests drive the real client
+ * against a JDK {@link HttpServer} stub that emits the same chunk sequences a
+ * live Ollama server produces.
+ */
+class OllamaClientStreamingTest {
+
+    private HttpServer server;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.setExecutor(Executors.newCachedThreadPool());
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // helpers
+    // -----------------------------------------------------------------
+
+    private static RestClient timedClient(int port, long readTimeoutMillis) {
+        RequestConfig cfg = RequestConfig.custom()
+                .setConnectTimeout(2, TimeUnit.SECONDS)
+                .setConnectionRequestTimeout(2, TimeUnit.SECONDS)
+                .setResponseTimeout(readTimeoutMillis, TimeUnit.MILLISECONDS)
+                .build();
+        CloseableHttpClient hc = HttpClients.custom().setDefaultRequestConfig(cfg).build();
+        return RestClient.builder()
+                .baseUrl("http://localhost:" + port)
+                .requestFactory(new HttpComponentsClientHttpRequestFactory(hc))
+                .defaultHeader("Content-Type", "application/json")
+                .build();
+    }
+
+    private OllamaClient client() {
+        return new OllamaClient(timedClient(server.getAddress().getPort(), 5000),
+                "test-model", 128, true);
+    }
+
+    /** Captures the last (input, output) token pair passed to reportUsage. */
+    private static final class CapturingRecorder implements AiAuditRecorder {
+        long input = -1;
+        long output = -1;
+        long invocations = 0;
+
+        @Override
+        public void recordUsage(long inputTokens, long outputTokens,
+                                long cacheCreation, long cacheRead,
+                                String rawRequest, String rawResponse) {
+            this.input = inputTokens;
+            this.output = outputTokens;
+            this.invocations++;
+        }
+
+        @Override
+        public void recordError(Throwable error) {
+        }
+    }
+
+    private void attachRecorder(OllamaClient client, CapturingRecorder recorder) {
+        client.setAuditRecorder(recorder);
+    }
+
+    private static void drain(HttpExchange exchange) throws IOException {
+        try (InputStream in = exchange.getRequestBody()) {
+            in.readAllBytes();
+        }
+    }
+
+    /** Emits the given NDJSON lines (one OllamaResponse per line) then closes. */
+    private void emitNdjson(String... lines) {
+        server.createContext("/api/chat", exchange -> {
+            try {
+                drain(exchange);
+                exchange.getResponseHeaders().set("Content-Type", "application/x-ndjson");
+                exchange.sendResponseHeaders(200, 0); // chunked
+                OutputStream os = exchange.getResponseBody();
+                for (String line : lines) {
+                    os.write(line.getBytes(StandardCharsets.UTF_8));
+                    os.write('\n');
+                    os.flush();
+                }
+            } catch (IOException e) {
+                // best effort
+            } finally {
+                exchange.close();
+            }
+        });
+        server.start();
+    }
+
+    // -----------------------------------------------------------------
+    // AC 1: NDJSON merge — concatenated text + counters from the final chunk
+    // -----------------------------------------------------------------
+
+    @Test
+    void ndjsonMerge_concatenatesContentAndTakesCountersFromFinalChunk() {
+        // The reference chunk stream from the incident report, with the final
+        // chunk carrying the usage counters (prompt_eval_count / eval_count).
+        emitNdjson(
+                "{\"model\":\"qwen3.8:latest\",\"created_at\":\"2026-01-01T00:00:00Z\","
+                        + "\"message\":{\"role\":\"assistant\",\"content\":\"Orange\"},\"done\":false}",
+                "{\"model\":\"qwen3.8:latest\",\"created_at\":\"2026-01-01T00:00:00Z\","
+                        + "\"message\":{\"role\":\"assistant\",\"content\":\" wavelengths\"},\"done\":false}",
+                "{\"model\":\"qwen3.8:latest\",\"created_at\":\"2026-01-01T00:00:00Z\","
+                        + "\"message\":{\"role\":\"assistant\",\"content\":\" dominate.\"},\"done\":false}",
+                "{\"model\":\"qwen3.8:latest\",\"created_at\":\"2026-01-01T00:00:00Z\","
+                        + "\"message\":{\"role\":\"assistant\",\"content\":\"\"},\"done\":true,"
+                        + "\"done_reason\":\"stop\",\"prompt_eval_count\":16,\"eval_count\":491}"
+        );
+
+        CapturingRecorder recorder = new CapturingRecorder();
+        OllamaClient client = client();
+        attachRecorder(client, recorder);
+
+        String review = client.submitReviewPrompt("You are a code reviewer.", null, "review this PR");
+
+        assertEquals("Orange wavelengths dominate.", review);
+        // Counters come from the single done:true chunk (not summed from others).
+        assertEquals(16L, recorder.input, "prompt tokens from final chunk");
+        assertEquals(491L, recorder.output, "eval tokens from final chunk");
+        assertEquals(1, recorder.invocations, "usage reported exactly once");
+    }
+
+    // -----------------------------------------------------------------
+    // AC 6: tool calls are emitted complete in the final chunk
+    // -----------------------------------------------------------------
+
+    @Test
+    void toolCalls_streamedFromFinalChunk_andSynthesizeIds() {
+        emitNdjson(
+                "{\"model\":\"m\",\"created_at\":\"t\","
+                        + "\"message\":{\"role\":\"assistant\",\"content\":\"\"},\"done\":false}",
+                "{\"model\":\"m\",\"created_at\":\"t\","
+                        + "\"message\":{\"role\":\"assistant\",\"content\":\"\","
+                        + "\"tool_calls\":[{\"function\":{\"name\":\"search\","
+                        + "\"arguments\":{\"query\":\"npe\"}}}]},"
+                        + "\"done\":true,\"done_reason\":\"stop\",\"prompt_eval_count\":10,\"eval_count\":5}"
+        );
+
+        OllamaClient client = client();
+        CapturingRecorder recorder = new CapturingRecorder();
+        attachRecorder(client, recorder);
+
+        ChatTurn turn = client.chatWithTools(
+                List.of(), "please search",
+                List.of(new ToolDescriptor("search", "search the code base", null)),
+                "You are an agent.", null, null);
+
+        assertTrue(turn.hasToolCalls(), "turn should carry the streamed tool call");
+        assertEquals(1, turn.toolCalls().size());
+        ToolCall call = turn.toolCalls().get(0);
+        assertEquals("search", call.name(), "sanitised name is desanitised back on read");
+        // Ollama supplies no call id; the client synthesises "<name>:<index>".
+        assertEquals("search:0", call.id());
+        assertEquals(StopReason.TOOL_USE, turn.stopReason());
+        assertEquals(10L, turn.inputTokens());
+        assertEquals(5L, turn.outputTokens());
+    }
+
+    // -----------------------------------------------------------------
+    // AC 5: usage parity — recorded totals are the final chunk's counters,
+    // not the sum of per-chunk counters.
+    // -----------------------------------------------------------------
+
+    @Test
+    void usageParity_recordsFinalChunkCountersNotASum() {
+        // Deliberately put (fake) per-chunk counters on the intermediate chunks.
+        // The merge must use the final chunk's values, not sum the stream.
+        emitNdjson(
+                "{\"model\":\"m\",\"message\":{\"role\":\"assistant\",\"content\":\"a\"},\"done\":false,\"eval_count\":5}",
+                "{\"model\":\"m\",\"message\":{\"role\":\"assistant\",\"content\":\"b\"},\"done\":false,\"eval_count\":10}",
+                "{\"model\":\"m\",\"message\":{\"role\":\"assistant\",\"content\":\"\"},\"done\":true,"
+                        + "\"done_reason\":\"stop\",\"prompt_eval_count\":16,\"eval_count\":491}"
+        );
+
+        OllamaClient client = client();
+        CapturingRecorder recorder = new CapturingRecorder();
+        attachRecorder(client, recorder);
+
+        String out = client.submitReviewPrompt("review", null, "hi");
+
+        assertEquals("ab", out);
+        assertEquals(16L, recorder.input, "input tokens = final chunk prompt_eval_count");
+        assertEquals(491L, recorder.output, "output tokens = final chunk eval_count (not 5+10+491)");
+    }
+
+    // -----------------------------------------------------------------
+    // edge case: empty stream (0 chunks) -> existing empty-response fallback
+    // -----------------------------------------------------------------
+
+    @Test
+    void emptyStream_returnsExistingEmptyResponseFallback() {
+        server.createContext("/api/chat", exchange -> {
+            try {
+                drain(exchange);
+                exchange.sendResponseHeaders(200, 0); // empty 200, no body
+            } catch (IOException e) {
+                // best effort
+            } finally {
+                exchange.close();
+            }
+        });
+        server.start();
+
+        OllamaClient client = client();
+        String out = client.submitReviewPrompt("review", null, "hi");
+        assertTrue(out.startsWith("Unable to generate review - empty response"),
+                "expected the historical empty-response fallback, got: " + out);
+    }
+}

--- a/src/test/java/org/remus/giteabot/ai/ollama/OllamaClientStreamingTest.java
+++ b/src/test/java/org/remus/giteabot/ai/ollama/OllamaClientStreamingTest.java
@@ -13,7 +13,10 @@ import org.remus.giteabot.ai.ChatTurn;
 import org.remus.giteabot.ai.StopReason;
 import org.remus.giteabot.ai.ToolCall;
 import org.remus.giteabot.ai.ToolDescriptor;
+import org.remus.giteabot.config.AiUsageProperties;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
 
 import java.io.IOException;
@@ -26,6 +29,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -80,6 +85,7 @@ class OllamaClientStreamingTest {
         long input = -1;
         long output = -1;
         long invocations = 0;
+        String lastRawResponse;
 
         @Override
         public void recordUsage(long inputTokens, long outputTokens,
@@ -87,6 +93,7 @@ class OllamaClientStreamingTest {
                                 String rawRequest, String rawResponse) {
             this.input = inputTokens;
             this.output = outputTokens;
+            this.lastRawResponse = rawResponse;
             this.invocations++;
         }
 
@@ -245,5 +252,57 @@ class OllamaClientStreamingTest {
         String out = client.submitReviewPrompt("review", null, "hi");
         assertTrue(out.startsWith("Unable to generate review - empty response"),
                 "expected the historical empty-response fallback, got: " + out);
+    }
+
+    // -----------------------------------------------------------------
+    // degraded stream: content arrives but the stream ends without a
+    // done:true chunk (provider/proxy truncation). The last chunk is the
+    // metadata fallback, so model metadata and any counters it carried
+    // must be preserved, not silently dropped.
+    // -----------------------------------------------------------------
+
+    @Test
+    void partialStreamWithoutDoneChunk_preservesModelMetadataFromLastChunk() {
+        // No final chunk: the stream simply ends after the last content chunk.
+        // The last chunk deliberately carries a model and (fake) counters.
+        emitNdjson(
+                "{\"model\":\"qwen3.8:latest\",\"created_at\":\"2026-01-01T00:00:00Z\","
+                        + "\"message\":{\"role\":\"assistant\",\"content\":\"partial \"},\"done\":false}",
+                "{\"model\":\"qwen3.8:latest\",\"created_at\":\"2026-01-01T00:00:00Z\","
+                        + "\"message\":{\"role\":\"assistant\",\"content\":\"text\"},\"done\":false,"
+                        + "\"prompt_eval_count\":7,\"eval_count\":3}"
+        );
+
+        AiUsageProperties props = new AiUsageProperties();
+        props.setRawPayloadsEnabled(true);
+
+        OllamaClient client = client();
+        client.setUsageProperties(props);
+        CapturingRecorder recorder = new CapturingRecorder();
+        attachRecorder(client, recorder);
+
+        String out = client.submitReviewPrompt("review", null, "hi");
+
+        assertEquals("partial text", out);
+        // Counters from the last chunk (not summed, not dropped).
+        assertEquals(7L, recorder.input, "prompt tokens from last chunk");
+        assertEquals(3L, recorder.output, "eval tokens from last chunk");
+        // Raw audit payload is serialized from the merged response, so the
+        // model metadata from the last chunk must be present in it.
+        assertNotNull(recorder.lastRawResponse, "raw payload should be captured");
+        assertTrue(recorder.lastRawResponse.contains("\"model\":\"qwen3.8:latest\""),
+                "model metadata must survive a stream without a done chunk, got: "
+                        + recorder.lastRawResponse);
+    }
+
+    @Test
+    void isPromptTooLongError_nullBody_doesNotThrowAndReturnsFalse() {
+        // A 4xx response without a body produces a null response body;
+        // classification must not turn that into an NPE during retry logic.
+        OllamaClient client = client();
+        HttpClientErrorException e = new HttpClientErrorException(
+                HttpStatus.BAD_REQUEST, "Bad Request", null, null, null);
+        assertFalse(client.isPromptTooLongError(e),
+                "null body is not a prompt-too-long error");
     }
 }

--- a/systemtest/docker-compose-ollama.yml
+++ b/systemtest/docker-compose-ollama.yml
@@ -7,6 +7,8 @@ services:
       - "11434:11434"
     volumes:
       - ollama_data:/root/.ollama
+    environment:
+      - OLLAMA_KEEP_ALIVE=-1
     healthcheck:
       test: ["CMD-SHELL", "ollama list || exit 1"]
       interval: 10s
@@ -17,7 +19,7 @@ services:
 
   ollama-pull:
     image: ollama/ollama:latest
-    entrypoint: ["sh", "-c", "sleep 5 && ollama pull ${AI_MODEL:-llama3.2:1b}"]
+    entrypoint: ["sh", "-c", "sleep 5 && ollama pull ${AI_MODEL:-qwen2.5-coder:7b}"]
     environment:
       OLLAMA_HOST: http://ollama:11434
     depends_on:


### PR DESCRIPTION
# What has been done?

Bug fix: local AI providers (Ollama, llama.cpp) now stream responses instead of requesting non-streamed ones, fixing intermittent ResourceAccessException: Read timed out failures on long PR reviews.

- New org.remus.giteabot.ai.StreamingLineReader — shared helper that POSTs via RestClient.exchange(...) and delivers the response line-by-line to a consumer. 4xx/5xx still produce the exact HttpClientErrorException via createException(), so prompt-too-long handling and retries are unchanged. No new dependencies.
- OllamaClient — sends stream: true on all /api/chat calls (review, chat, chatWithTools) and merges the NDJSON chunks: content concatenated, done_reason/prompt_eval_count/eval_count/tool_calls taken from the single done:true chunk.
- LlamaCppClient — sends stream: true on all /completion calls and merges the SSE (data: {json}) chunks, stripping framing and tolerating data: [DONE]; counters and stopped_limit from the stop:true chunk. GBNF grammar, cache_prompt, stop sequences and the truncation warning are untouched.
- 0-chunk streams still hit the existing "empty response" fallback; malformed lines fail the request as an I/O error (retried by AgentLoop.callAiWithRetry).
- systemtest/docker-compose-ollama.yml — OLLAMA_KEEP_ALIVE=-1 (keep model resident) and default pull model changed llama3.2:1b → qwen2.5-coder:7b.

# Why?

A non-streamed request makes the server emit zero bytes until the entire generation completes (model load + prompt eval + tokens — e.g. 111 s in the incident report). The configured spring.http.clients.read-timeout therefore acted as a whole-request budget, so slow local models failed intermittently exactly "when the AI needs more time to review a PR" — and raising the timeout is an unbounded guessing game that also multiplies retry waits, with a hung server indistinguishable from a slow one.

With streaming, bytes flow continuously (each chunk resets the socket read), so the read timeout becomes a per-chunk stall detector: slow-but-alive models never trip it, while a truly wedged server still fails fast. Model-load time still counts (no chunks are emitted during load) — a documented, accepted limitation.

# What has been tested?

New tests (all drive the real clients against a JDK HttpServer stub with a real 2 s Apache-HC5 read timeout — no WireMock, no Spring context, matching the project's existing OllamaReadTimeoutIT convention):

Manual system-tests were executed with an Agent-based review worfklow including the decision making. Hardware: Laptop with 32GB RAM and 4GB dedicated VRAM
1. Ollama with `qwen2.5-coder:7b` and the environemt-variable `OLLAMA_KEEP_ALIVE=-1` — this prevents Ollama from evicting a loaded model.
2. llama.cpp with qwen2.5-coder-7b-instruct-q4_k_m.gguf

# How AI was used?

Initial implemenation by an AI coding agent (Hermes Agent, Nous Research, running a local Qwen model) acting as a human-in-the-loop pair-programming session — the user directed scope (the issue) and decisions; the agent did the rest: human fixed code-smells and provided the `/spring-developer`skill